### PR TITLE
String representation property wrapper

### DIFF
--- a/Say Their Names.xcodeproj/project.pbxproj
+++ b/Say Their Names.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		9DCEF35C24A9829000546A8E /* BundleDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCEF35B24A9829000546A8E /* BundleDecoder.swift */; };
 		9DCEF36024A9830A00546A8E /* IncidentRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DCEF35F24A9830A00546A8E /* IncidentRecord.swift */; };
 		9DCEF36224A988A800546A8E /* shooting-incidents.json in Resources */ = {isa = PBXBuildFile; fileRef = 9DCEF36124A9838C00546A8E /* shooting-incidents.json */; };
+		A0977F0624AAD4D200FCBC34 /* StringRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0977F0524AAD4D200FCBC34 /* StringRepresentation.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +56,7 @@
 		9DCEF35B24A9829000546A8E /* BundleDecoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BundleDecoder.swift; sourceTree = "<group>"; };
 		9DCEF35F24A9830A00546A8E /* IncidentRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IncidentRecord.swift; sourceTree = "<group>"; };
 		9DCEF36124A9838C00546A8E /* shooting-incidents.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shooting-incidents.json"; sourceTree = "<group>"; };
+		A0977F0524AAD4D200FCBC34 /* StringRepresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringRepresentation.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 				9DCEF32D24A9820D00546A8E /* SceneDelegate.swift */,
 				9DCEF32F24A9820D00546A8E /* ContentView.swift */,
 				9DCEF35F24A9830A00546A8E /* IncidentRecord.swift */,
+				A0977F0524AAD4D200FCBC34 /* StringRepresentation.swift */,
 				9DCEF33124A9821000546A8E /* Assets.xcassets */,
 				9DCEF33624A9821000546A8E /* LaunchScreen.storyboard */,
 				9DCEF33924A9821000546A8E /* Info.plist */,
@@ -161,6 +164,8 @@
 			dependencies = (
 			);
 			name = "Say Their Names";
+			packageProductDependencies = (
+			);
 			productName = "Say Their Names";
 			productReference = 9DCEF32824A9820D00546A8E /* Say Their Names.app */;
 			productType = "com.apple.product-type.application";
@@ -232,6 +237,8 @@
 				Base,
 			);
 			mainGroup = 9DCEF31F24A9820D00546A8E;
+			packageReferences = (
+			);
 			productRefGroup = 9DCEF32924A9820D00546A8E /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -277,6 +284,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9DCEF32C24A9820D00546A8E /* AppDelegate.swift in Sources */,
+				A0977F0624AAD4D200FCBC34 /* StringRepresentation.swift in Sources */,
 				9DCEF32E24A9820D00546A8E /* SceneDelegate.swift in Sources */,
 				9DCEF35C24A9829000546A8E /* BundleDecoder.swift in Sources */,
 				9DCEF36024A9830A00546A8E /* IncidentRecord.swift in Sources */,

--- a/Say Their Names/IncidentRecord.swift
+++ b/Say Their Names/IncidentRecord.swift
@@ -11,105 +11,32 @@ import Network
 struct IncidentRecord: Codable, Hashable {
     let id = UUID()
     let victimName: String
-    let victimAge: Int?
+    @StringRepresentation private(set) var victimAge: Int?
     let victimGender: String
     let victimRace: String
-    let imageURL: URL?
-    let incidentDate: Date?
+    @StringRepresentation private(set) var imageURL: URL?
+    @StringRepresentation private(set) var incidentDate: Date?
     let streetAddress: String
     let city: String
     let state: String
-    let zipcode: String
+    @StringRepresentation private(set) var zipcode: Int?
     let responsibleAgency: String
-//    let causeOfDeath: String
-//    let briefDescription: String
-//    let officialDisposition: String
-//    let criminalCharges: String
-    let newsURL: URL?
-//    let symptomsOfMentalIllness: String
-//    let reportedArmedState: String
-//    let allegedWeapon: String
-//    let allegedThreatLevel: String
-//    let fleeingType: String
-//    let bodyCameraActive: String
-//    let wapoId: Int?
-//    let offDutyKilling: String
-//    let geographyCategory: String
-//    let idInfo: String
+    let causeOfDeath: String
+    let briefDescription: String
+    let officialDisposition: String
+    let criminalCharges: String
+    @StringRepresentation private(set) var newsURL: URL?
+    let symptomsOfMentalIllness: String
+    let reportedArmedState: String
+    let allegedWeapon: String
+    let allegedThreatLevel: String
+    let fleeingType: String
+    let bodyCameraActive: String
+    @StringRepresentation private(set) var wapoId: Int?
+    let offDutyKilling: String
+    let geographyCategory: String
+    @StringRepresentation private(set) var idInfo: Int?
     
-//    init(from decoder: Decoder) throws {
-//        let values = try decoder.container(keyedBy: CodingKeys.self)
-//        imageURL = try values.decode(URL.self, forKey: .imageURL)
-//    }
-
-//    func getImageURL() -> URL? {
-//        guard let url = URL(string: self.imageURL) else { return nil }
-//        return url
-//    }
-    
-    init(from decoder: Decoder) throws {
-        let map = try decoder.container(keyedBy: CodingKeys.self)
-        do {
-            self.victimName = try map.decode(String.self, forKey: .victimName)
-        } catch {
-            self.victimName = ""
-        }
-        do {
-            self.victimAge = try map.decode(Int.self, forKey: .victimAge)
-        } catch {
-            self.victimAge = nil
-        }
-        do {
-            self.victimGender = try map.decode(String.self, forKey: .victimGender)
-        } catch {
-            self.victimGender = "Unknown"
-        }
-        do {
-            self.victimRace = try map.decode(String.self, forKey: .victimRace)
-        } catch {
-            self.victimRace = "Unknown"
-        }
-        do {
-            self.imageURL = try map.decode(URL.self, forKey: .imageURL)
-        } catch {
-            self.imageURL = nil
-        }
-        do {
-            self.incidentDate = try map.decode(Date.self, forKey: .incidentDate)
-        } catch {
-            self.incidentDate = nil
-        }
-        do {
-            self.streetAddress = try map.decode(String.self, forKey: .streetAddress)
-        } catch {
-            self.streetAddress = "Unknown"
-        }
-        do {
-            self.city = try map.decode(String.self, forKey: .city)
-        } catch {
-            self.city = "Unknown"
-        }
-        do {
-            self.state = try map.decode(String.self, forKey: .state)
-        } catch {
-            self.state = "Unknown"
-        }
-        do {
-            self.zipcode = try map.decode(String.self, forKey: .zipcode)
-        } catch {
-            self.zipcode = "Unknown"
-        }
-        do {
-            self.responsibleAgency = try map.decode(String.self, forKey: .responsibleAgency)
-        } catch {
-            self.responsibleAgency = "unknown agency"
-        }
-        do {
-            self.newsURL = try map.decode(URL.self, forKey: .newsURL)
-        } catch {
-            self.newsURL = nil
-        }
-    }
 }
 
 //"victim_name": "Chazz Hailey",

--- a/Say Their Names/StringRepresentation.swift
+++ b/Say Their Names/StringRepresentation.swift
@@ -1,0 +1,79 @@
+//
+//  StringRepresentation.swift
+//  Say Their Names
+//
+//  Created by Jacob Martin on 6/29/20.
+//
+
+import Foundation
+
+// MARK: Property Wrapper
+@propertyWrapper
+struct StringRepresentation<T: LosslessStringConvertible> {
+    private var value: T?
+
+    var wrappedValue: T? {
+        get {
+            return value
+        }
+        set {
+            value = newValue
+        }
+    }
+    
+    init(value: T) {
+        self.value = value
+    }
+}
+
+// MARK: Codable Conformance
+extension StringRepresentation: Codable {
+    init(from decoder: Decoder) throws {
+        let string = try? String(from: decoder)
+        value = string.flatMap(T.init)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        if let value = value {
+            try "\(value)".encode(to: encoder)
+        } else {
+            // encodes to null, or {} if commented
+            try Optional<String>.none.encode(to: encoder)
+        }
+    }
+}
+
+// MARK: Equatable Conditional Conformance
+extension StringRepresentation: Equatable where T: Equatable {
+    static func == (lhs: StringRepresentation<T>, rhs: StringRepresentation<T>) -> Bool {
+        return lhs.value == rhs.value
+    }
+}
+
+// MARK: Hashable Conditional Conformance
+extension StringRepresentation: Hashable where T: Hashable {}
+
+
+// MARK: URL Compatibility
+extension URL: LosslessStringConvertible {
+    public init?(_ description: String) {
+        guard let url = URL(string: description) else {
+            return nil
+        }
+        
+        self = url
+    }
+}
+
+// MARK: Date Compatibility
+extension Date: LosslessStringConvertible {
+    public init?(_ description: String) {
+        let formatter =  DateFormatter()
+        formatter.dateFormat = "M/D/yy"
+        guard let date = formatter.date(from: description) else {
+            return nil
+        }
+        
+        self = date
+    }
+}


### PR DESCRIPTION
# StringRepresentation
Remove that cumbersome `Codable` boilerplate with `StringRepresentation`; A property wrapper that codes between any `T: LosslessStringConvertible` and `String`

Notes: in implementing `Date` conformance to `LosslessStringConvertible` I took a guess at the correct formatting. Take care in reviewing that.